### PR TITLE
Added dev-gluonts requirement & added min_instances to dataloader

### DIFF
--- a/megatron/laggpt/dataloaders.py
+++ b/megatron/laggpt/dataloaders.py
@@ -82,7 +82,7 @@ def get_training_data_loader(
     
     data = transform.apply(data, is_train=True)
     
-    sampler = ExpectedNumInstanceSampler(num_instances=1.0, min_future=prediction_length)
+    sampler = ExpectedNumInstanceSampler(num_instances=1.0, min_instances=1, min_future=prediction_length)
     instance_splitter = create_instance_splitter(sampler, prediction_length, past_length, padding_value)
     data = instance_splitter.apply(Cyclic(data).stream(), is_train=True)
     

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -13,3 +13,4 @@ six
 tiktoken>=0.1.2
 tokenizers>=0.12.1
 transformers>=4.24.0
+git+https://github.com/awslabs/gluonts.git


### PR DESCRIPTION
### Issue
Gluon-ts data loader occasionally throws "Exception: Reached maximum number of idle transformation calls" on the transformation call from gluonts.transform.split.InstanceSplitter. I.e., sometimes the data loader can't get enough valid samples from the dataset.

### Changes
Added "min_instances=1" argument (only available in dev version of gluonts) to data loader initialization.